### PR TITLE
Multi-Checkbox support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ south
 
 # Templates
 django-jstemplate>=1.3.6
-django_compressor
+django_compressor<2.0
 
 # Web interface helpers
 django-proxy>=1.0.2

--- a/src/flavors/default/config.yml
+++ b/src/flavors/default/config.yml
@@ -139,7 +139,22 @@ place:
         - key: placeholder
           value: _(Email address)
         - key: size
-          value: 30      
+          value: 30
+    - prompt: _(Features)
+      type: multi-checkbox
+      name: features
+      optional: true
+      checkboxes:
+        - name: mad_jumps
+          label: Mad jumps
+        - name: sick_rails
+          label: Sick rails
+        - name: half-pipes
+          label: Half Pipes
+        - name: long_board_friendly
+          label: Long Board Friendly
+        - name: friday_specials
+          label: Friday Specials
 
 survey:
   submission_type: comments

--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -71,6 +71,15 @@
               <!--<![endif]-->
               {{/is_file}}
 
+              {{#is_multi_checkbox}}
+                {{#checkboxes}}
+                  <label class="multi-checkbox" for="multi-checkbox-{{name}}">
+                    <input type="checkbox" id="multi-checkbox-{{name}}" name="{{name}}" value="1">
+                    {{label}}
+                  </label>
+                {{/checkboxes}}
+              {{/is_multi_checkbox}}
+
               {{#if help_text }}
               <div class="help-text place-{{ name }}-help-text">{{ help_text }}</div>
               {{/if}}

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -238,6 +238,9 @@ textarea {
   height: 6.5em;
   resize: none;
 }
+label.multi-checkbox {
+  display: block;
+}
 .form-submitted input:invalid,
 .form-submitted textarea:invalid,
 .form-submitted select:invalid {

--- a/src/sa_web/static/js/template-helpers.js
+++ b/src/sa_web/static/js/template-helpers.js
@@ -5,11 +5,12 @@ var Shareabouts = Shareabouts || {};
     // Attached helper properties for how to display this form element
     insertInputTypeFlags: function(configItems) {
       _.each(configItems, function(item, index) {
-        item.is_input = (!item.type || (item.type !== 'textarea' && item.type !== 'select' && item.type !== 'file'));
+        item.is_input = (!item.type || (item.type !== 'textarea' && item.type !== 'select' && item.type !== 'file' && item.type !== 'multi-checkbox' ));
         item.is_textarea = (item.type === 'textarea');
         item.is_select = (item.type === 'select');
         item.is_file = (item.type === 'file');
         item.is_fileinput_supported = S.Util.fileInputSupported();
+        item.is_multi_checkbox = (item.type === 'multi-checkbox');
       });
     },
 


### PR DESCRIPTION
This PR provides support for a `multi-checkbox` type of input that can be defined in a config file that will be used when the user creates a place. An example of how to use the new type can be found in https://github.com/CrowdSpot/shareabouts/commit/d91ed966cdd3c07c15bd99e1c416a1ba8afc4108

This allows the user to check defined checkbox individually and items that are checked are stored within the database on the `Place` model for the `data` attribute as below;

```json
{
  "private-submitter_email": "", 
  "description": "", 
  "mad_jumps": "1", 
  "user_token": "user:1", 
  "half-pipes": "1", 
  "location_type": "wifi", 
  "name": "The Place"
}
```
